### PR TITLE
Updated codebase to Swift 3.0

### DIFF
--- a/Source/TIPBadgeManager.swift
+++ b/Source/TIPBadgeManager.swift
@@ -45,7 +45,7 @@ public class TIPBadgeManager {
     }
     
     func setAppIconBadgeValue(_ value : Int) {
-        UIApplication.shared().applicationIconBadgeNumber = value
+        UIApplication.shared.applicationIconBadgeNumber = value
     }
     
     public func getBadgeValue(_ key : String) -> Int? {

--- a/Source/TIPBadgeManager.swift
+++ b/Source/TIPBadgeManager.swift
@@ -16,7 +16,7 @@ public class TIPBadgeManager {
     
     private init() {}
     
-    public func addBadgeSuperview(name: String, view: AnyObject){
+    public func addBadgeSuperview(_ name: String, view: AnyObject){
         var badgeObj: TIPBadgeObject?
         
         if let superView = view as? UIView {
@@ -28,11 +28,11 @@ public class TIPBadgeManager {
         tipBadgeObjDict[name] = badgeObj!
     }
     
-    public func setBadgeValue(key : String, value : Int){
+    public func setBadgeValue(_ key : String, value : Int){
         tipBadgeObjDict[key]?.badgeValue = value
     }
     
-    public func setAllBadgeValues(value : Int, appIconBadge: Bool){
+    public func setAllBadgeValues(_ value : Int, appIconBadge: Bool){
         for (key, _) in tipBadgeObjDict {
             if !isTIPViewObjNil(tipBadgeObjDict[key]!) || !isTIPTabBarItemObjNil(tipBadgeObjDict[key]!){
                 setBadgeValue(key, value: value)
@@ -44,11 +44,11 @@ public class TIPBadgeManager {
         }
     }
     
-    func setAppIconBadgeValue(value : Int) {
-        UIApplication.sharedApplication().applicationIconBadgeNumber = value
+    func setAppIconBadgeValue(_ value : Int) {
+        UIApplication.shared().applicationIconBadgeNumber = value
     }
     
-    public func getBadgeValue(key : String) -> Int? {
+    public func getBadgeValue(_ key : String) -> Int? {
         if tipBadgeObjDict[key] != nil {
             if !isTIPViewObjNil(tipBadgeObjDict[key]!) || !isTIPTabBarItemObjNil(tipBadgeObjDict[key]!){
                 return tipBadgeObjDict[key]!.badgeValue
@@ -57,7 +57,7 @@ public class TIPBadgeManager {
        return nil
     }
     
-    func isTIPViewObjNil(tipBadgeObject: TIPBadgeObject) -> Bool{
+    func isTIPViewObjNil(_ tipBadgeObject: TIPBadgeObject) -> Bool{
         if let tipViewObject = tipBadgeObject as? TIPViewObject {
             if tipViewObject.view != nil {
                 return false
@@ -66,7 +66,7 @@ public class TIPBadgeManager {
         return true
     }
     
-    func isTIPTabBarItemObjNil(tipBadgeObject: TIPBadgeObject) -> Bool{
+    func isTIPTabBarItemObjNil(_ tipBadgeObject: TIPBadgeObject) -> Bool{
         if let tipTabBarItemObject = tipBadgeObject as? TIPTabBarItemObject {
             if tipTabBarItemObject.tabBar != nil {
                 return false
@@ -75,7 +75,7 @@ public class TIPBadgeManager {
         return true
     }
     
-    public func clearAllBadgeValues(clearAppIconBadge: Bool){
+    public func clearAllBadgeValues(_ clearAppIconBadge: Bool){
         clearAllBadgeValues()
         if clearAppIconBadge { setAppIconBadgeValue(0) }
     }
@@ -87,9 +87,9 @@ public class TIPBadgeManager {
     }
     
     
-    public func removeBadgeObjFromDict(keys : [String]) {
+    public func removeBadgeObjFromDict(_ keys : [String]) {
         for key in keys {
-            tipBadgeObjDict.removeValueForKey(key)
+            tipBadgeObjDict.removeValue(forKey: key)
         }
     }
     
@@ -105,14 +105,14 @@ public class TIPBadgeManager {
         }
     }
     
-    func cleanTipViewObject(key : String){
+    func cleanTipViewObject(_ key : String){
         let tipViewObj : TIPViewObject = tipBadgeObjDict[key] as! TIPViewObject
         if tipViewObj.view == nil {
             removeBadgeObjFromDict([key])
         }
     }
     
-    func cleanTipTabBarItemObject(key : String){
+    func cleanTipTabBarItemObject(_ key : String){
         let tipTabBarItemObj : TIPTabBarItemObject = tipBadgeObjDict[key] as! TIPTabBarItemObject
         if tipTabBarItemObj.tabBar == nil {
             removeBadgeObjFromDict([key])

--- a/Source/TIPBadgeObject.swift
+++ b/Source/TIPBadgeObject.swift
@@ -36,20 +36,20 @@ public class TIPViewObject: NSObject, TIPBadgeObject{
         
        bv!.translatesAutoresizingMaskIntoConstraints = false
         
-        let badgeHeightConstraint = NSLayoutConstraint(item: bv!, attribute: NSLayoutAttribute.Height, relatedBy: NSLayoutRelation.Equal, toItem: nil, attribute: NSLayoutAttribute.Height, multiplier: 1.0, constant: 18.0)
+        let badgeHeightConstraint = NSLayoutConstraint(item: bv!, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: nil, attribute: NSLayoutAttribute.height, multiplier: 1.0, constant: 18.0)
         
         bv!.addConstraints([badgeHeightConstraint])
         
-        let rightConstraint = NSLayoutConstraint(item: self.view!, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: bv!, attribute: NSLayoutAttribute.Left, multiplier: 1.0, constant: 7.0)
+        let rightConstraint = NSLayoutConstraint(item: self.view!, attribute: NSLayoutAttribute.right, relatedBy: NSLayoutRelation.equal, toItem: bv!, attribute: NSLayoutAttribute.left, multiplier: 1.0, constant: 7.0)
         
-        let topConstraint = NSLayoutConstraint(item: self.view!, attribute: NSLayoutAttribute.Top, relatedBy: NSLayoutRelation.Equal, toItem: bv!, attribute: NSLayoutAttribute.Top, multiplier: 1.0, constant: 5.0)
+        let topConstraint = NSLayoutConstraint(item: self.view!, attribute: NSLayoutAttribute.top, relatedBy: NSLayoutRelation.equal, toItem: bv!, attribute: NSLayoutAttribute.top, multiplier: 1.0, constant: 5.0)
         
         self.view!.addConstraints([rightConstraint, topConstraint])
         
         self.badgeView = bv
     }
     
-    public func changeBadgeValue(value : Int){
+    public func changeBadgeValue(_ value : Int){
         if value > 0 {
             if self.badgeView == nil {
                 addBadge()
@@ -84,7 +84,7 @@ public class TIPTabBarItemObject: NSObject, TIPBadgeObject {
         super.init()
     }
     
-    public func changeBadgeValue(value : Int){
+    public func changeBadgeValue(_ value : Int){
         if value > 0 {
             self.tabBar!.badgeValue = "\(value)"
         } else {

--- a/Source/TIPBadgeView.swift
+++ b/Source/TIPBadgeView.swift
@@ -21,7 +21,7 @@ public class TIPBadgeView: UIView {
     
     public init(){
         super.init(frame: CGRect(x: 0, y: 0, width: 18, height: 18))
-        self.backgroundColor = UIColor.red()
+        self.backgroundColor = UIColor.red
         self.layer.zPosition = 1000
         self.layer.cornerRadius = 9
         self.layer.masksToBounds = true
@@ -35,8 +35,8 @@ public class TIPBadgeView: UIView {
     func addLabel(){
         label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.backgroundColor = UIColor.clear()
-        label.textColor = UIColor.white()
+        label.backgroundColor = UIColor.clear
+        label.textColor = UIColor.white
         label.textAlignment = NSTextAlignment.left
         label.font = UIFont(name: self.label.font.fontName, size: 12.0)
         label.layer.cornerRadius = 9

--- a/Source/TIPBadgeView.swift
+++ b/Source/TIPBadgeView.swift
@@ -21,7 +21,7 @@ public class TIPBadgeView: UIView {
     
     public init(){
         super.init(frame: CGRect(x: 0, y: 0, width: 18, height: 18))
-        self.backgroundColor = UIColor.redColor()
+        self.backgroundColor = UIColor.red()
         self.layer.zPosition = 1000
         self.layer.cornerRadius = 9
         self.layer.masksToBounds = true
@@ -35,9 +35,9 @@ public class TIPBadgeView: UIView {
     func addLabel(){
         label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.backgroundColor = UIColor.clearColor()
-        label.textColor = UIColor.whiteColor()
-        label.textAlignment = NSTextAlignment.Left
+        label.backgroundColor = UIColor.clear()
+        label.textColor = UIColor.white()
+        label.textAlignment = NSTextAlignment.left
         label.font = UIFont(name: self.label.font.fontName, size: 12.0)
         label.layer.cornerRadius = 9
         label.layer.masksToBounds = true
@@ -47,25 +47,25 @@ public class TIPBadgeView: UIView {
     }
     
     func addLabelConstraints(){
-        topLabelConstraint = NSLayoutConstraint(item: self, attribute: NSLayoutAttribute.Top, relatedBy: NSLayoutRelation.Equal, toItem: self.label!, attribute: NSLayoutAttribute.Top, multiplier: 1.0, constant: 0)
+        topLabelConstraint = NSLayoutConstraint(item: self, attribute: NSLayoutAttribute.top, relatedBy: NSLayoutRelation.equal, toItem: self.label!, attribute: NSLayoutAttribute.top, multiplier: 1.0, constant: 0)
         
-        bottomLabelConstraint = NSLayoutConstraint(item: self, attribute: NSLayoutAttribute.Bottom, relatedBy: NSLayoutRelation.Equal, toItem: self.label!, attribute: NSLayoutAttribute.Bottom, multiplier: 1.0, constant: 0)
+        bottomLabelConstraint = NSLayoutConstraint(item: self, attribute: NSLayoutAttribute.bottom, relatedBy: NSLayoutRelation.equal, toItem: self.label!, attribute: NSLayoutAttribute.bottom, multiplier: 1.0, constant: 0)
         
-        leftLabelConstraint = NSLayoutConstraint(item: self.label, attribute: NSLayoutAttribute.Left, relatedBy: NSLayoutRelation.Equal, toItem: self, attribute: NSLayoutAttribute.Left, multiplier: 1.0, constant: 2.0)
+        leftLabelConstraint = NSLayoutConstraint(item: self.label, attribute: NSLayoutAttribute.left, relatedBy: NSLayoutRelation.equal, toItem: self, attribute: NSLayoutAttribute.left, multiplier: 1.0, constant: 2.0)
         leftLabelConstraint!.priority = 1000.0
         
-        rightLabelConstraint = NSLayoutConstraint(item: self, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: self.label, attribute: NSLayoutAttribute.Right, multiplier: 1.0, constant: 2.0)
+        rightLabelConstraint = NSLayoutConstraint(item: self, attribute: NSLayoutAttribute.right, relatedBy: NSLayoutRelation.equal, toItem: self.label, attribute: NSLayoutAttribute.right, multiplier: 1.0, constant: 2.0)
         rightLabelConstraint!.priority = 1000.0
         
         self.addConstraints([topLabelConstraint!, bottomLabelConstraint!, leftLabelConstraint!, rightLabelConstraint!])
     }
     
-    public func setBadgeValue(val : Int){
+    public func setBadgeValue(_ val : Int){
             label.text = " \(val) "
             setMarginsForVal(val)
     }
     
-    public func setMarginsForVal(val : Int){
+    public func setMarginsForVal(_ val : Int){
         if val < 10 {
             leftLabelConstraint!.constant = LARGER_MARGIN
             rightLabelConstraint!.constant = LARGER_MARGIN

--- a/TIPBadgeManager.xcodeproj/project.pbxproj
+++ b/TIPBadgeManager.xcodeproj/project.pbxproj
@@ -178,14 +178,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "John Coschigano";
 				TargetAttributes = {
 					FD1F57E61B31C71C00D87939 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					FD1F57F11B31C71C00D87939 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -361,6 +363,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.tippo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -378,6 +381,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.tippo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -396,6 +401,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.tippo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -410,6 +416,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.tippo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/TIPBadgeManager.xcodeproj/xcshareddata/xcschemes/TIPBadgeManager.xcscheme
+++ b/TIPBadgeManager.xcodeproj/xcshareddata/xcschemes/TIPBadgeManager.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/TIPBadgeManagerTests.swift
+++ b/Tests/TIPBadgeManagerTests.swift
@@ -36,7 +36,7 @@ class TIPBadgeManagerTests: XCTestCase {
         XCTAssert(isBadgeObjectAvalable(TAB_BAR_NAME), "TIPBadgeManager should add badge object to tipBadgeObjDict")
     }
     
-    func isBadgeObjectAvalable(name: String) -> Bool{
+    func isBadgeObjectAvalable(_ name: String) -> Bool{
         if TIPBadgeManager.sharedInstance.tipBadgeObjDict[name] != nil {
             return true
         } else {
@@ -88,9 +88,9 @@ class TIPBadgeManagerTests: XCTestCase {
         
         TIPBadgeManager.sharedInstance.setBadgeValue(VIEW_NAME, value: viewBadgeVal)
         TIPBadgeManager.sharedInstance.setBadgeValue(TAB_BAR_NAME, value: tabBarItemBadgeVal)
-        let settings = UIUserNotificationSettings(forTypes: UIUserNotificationType.Badge, categories: nil)
-        UIApplication.sharedApplication().registerUserNotificationSettings(settings)
-        UIApplication.sharedApplication().applicationIconBadgeNumber = appIconVal
+        let settings = UIUserNotificationSettings(types: UIUserNotificationType.badge, categories: nil)
+        UIApplication.shared().registerUserNotificationSettings(settings)
+        UIApplication.shared().applicationIconBadgeNumber = appIconVal
     }
     
     func areObjectBadgeValuesZero() -> Bool{

--- a/Tests/TIPBadgeManagerTests.swift
+++ b/Tests/TIPBadgeManagerTests.swift
@@ -89,8 +89,8 @@ class TIPBadgeManagerTests: XCTestCase {
         TIPBadgeManager.sharedInstance.setBadgeValue(VIEW_NAME, value: viewBadgeVal)
         TIPBadgeManager.sharedInstance.setBadgeValue(TAB_BAR_NAME, value: tabBarItemBadgeVal)
         let settings = UIUserNotificationSettings(types: UIUserNotificationType.badge, categories: nil)
-        UIApplication.shared().registerUserNotificationSettings(settings)
-        UIApplication.shared().applicationIconBadgeNumber = appIconVal
+        UIApplication.shared.registerUserNotificationSettings(settings)
+        UIApplication.shared.applicationIconBadgeNumber = appIconVal
     }
     
     func areObjectBadgeValuesZero() -> Bool{

--- a/Tests/TIPBadgeViewTests.swift
+++ b/Tests/TIPBadgeViewTests.swift
@@ -40,7 +40,7 @@ class TIPBadgeViewTests: XCTestCase {
         assert(constraintsAreEqualTo(largerMargin), "setMarginsForVal should set val to LARGER_MARGIN")
     }
     
-    func constraintsAreEqualTo(val : CGFloat) -> Bool{
+    func constraintsAreEqualTo(_ val : CGFloat) -> Bool{
         if tipBadgeView!.leftLabelConstraint!.constant == val && tipBadgeView!.rightLabelConstraint!.constant == val {
             return true
         } else {


### PR DESCRIPTION
@johncosch 

Here's a fix for https://github.com/johncosch/TIPBadgeManager/issues/11
There is no more error or warnings on Xcode 8 beta 2. All of the migration work was done automatically with the Xcode migration tool (that was surprising).

I would suggest to merge this code in a specific `swift-3.0` branch until Xcode 8 gets released.

Let me know if you have any question.
